### PR TITLE
Switch storage from JSON to SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 tweets.json
+tweets.db

--- a/app.py
+++ b/app.py
@@ -1,19 +1,76 @@
 # app.py
-import json, datetime
+import datetime
+import sqlite3
 from flask import Flask, request, jsonify, send_from_directory
 from collections import Counter
 
 app = Flask(__name__, static_folder='static')
-TWEETS_FILE = 'tweets.json'
+
+DB_FILE = 'tweets.db'
+
+def init_db():
+    """Create the SQLite database and tweets table if they don't exist."""
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS tweets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT NOT NULL,
+            text TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            replying_to INTEGER,
+            quoting_tweet_id INTEGER,
+            like_count INTEGER DEFAULT 0
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
 
 def load_tweets():
-    try:
-        with open(TWEETS_FILE, 'r') as f: return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return []
+    conn = sqlite3.connect(DB_FILE)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute('SELECT * FROM tweets')
+    tweets = [dict(row) for row in cur.fetchall()]
+    conn.close()
+    return tweets
 
-def save_tweets(tweets):
-    with open(TWEETS_FILE, 'w') as f: json.dump(tweets, f, indent=2)
+def insert_tweet(tweet):
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        'INSERT INTO tweets (username, text, timestamp, replying_to, quoting_tweet_id, like_count) VALUES (?, ?, ?, ?, ?, ?)',
+        (
+            tweet['username'],
+            tweet['text'],
+            tweet['timestamp'],
+            tweet['replying_to'],
+            tweet['quoting_tweet_id'],
+            tweet['like_count'],
+        ),
+    )
+    conn.commit()
+    tweet_id = cur.lastrowid
+    conn.close()
+    return tweet_id
+
+def get_tweet(tweet_id):
+    conn = sqlite3.connect(DB_FILE)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    cur.execute('SELECT * FROM tweets WHERE id=?', (tweet_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+def increment_like(tweet_id):
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute('UPDATE tweets SET like_count = COALESCE(like_count, 0) + 1 WHERE id=?', (tweet_id,))
+    conn.commit()
+    conn.close()
 
 def add_interaction_counts(tweets):
     reply_counts = Counter(t['replying_to'] for t in tweets if t.get('replying_to'))
@@ -46,7 +103,8 @@ def get_tweet_by_id(tweet_id):
     all_tweets = load_tweets()
     all_tweets_with_counts = add_interaction_counts(all_tweets)
     tweet = next((t for t in all_tweets_with_counts if t.get('id') == tweet_id), None)
-    if tweet: return jsonify(tweet)
+    if tweet:
+        return jsonify(tweet)
     return jsonify({'error': 'Tweet not found'}), 404
 
 @app.route('/api/tweets', methods=['POST'])
@@ -55,35 +113,29 @@ def post_tweet():
     if not tweet_data or 'username' not in tweet_data or 'text' not in tweet_data:
         return jsonify({'error': 'Missing data'}), 400
 
-    tweets = load_tweets()
     new_tweet = {
-        'id': len(tweets) + 1,
         'username': tweet_data['username'],
         'text': tweet_data['text'],
         'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
         'replying_to': tweet_data.get('replying_to', None),
         'quoting_tweet_id': tweet_data.get('quoting_tweet_id', None),
-        'like_count': 0  # Add like_count on creation
+        'like_count': 0,
     }
-    
-    tweets.append(new_tweet)
-    save_tweets(tweets)
+
+    new_tweet['id'] = insert_tweet(new_tweet)
     return jsonify(new_tweet), 201
 
 @app.route('/api/tweets/<int:tweet_id>/like', methods=['POST'])
 def like_tweet(tweet_id):
     """New endpoint to increment a tweet's like count."""
-    tweets = load_tweets()
-    tweet = next((t for t in tweets if t.get('id') == tweet_id), None)
-    
+    tweet = get_tweet(tweet_id)
     if not tweet:
         return jsonify({'error': 'Tweet not found'}), 404
-    
-    tweet['like_count'] = tweet.get('like_count', 0) + 1
-    save_tweets(tweets)
-    
-    # Add interaction counts to the returned tweet for UI consistency
-    tweet_with_counts = add_interaction_counts([tweet])[0]
+
+    increment_like(tweet_id)
+    updated_tweet = get_tweet(tweet_id)
+
+    tweet_with_counts = add_interaction_counts([updated_tweet])[0]
     return jsonify(tweet_with_counts)
 
 @app.route('/')
@@ -93,6 +145,9 @@ def serve_index():
 @app.route('/<path:path>')
 def serve_static(path):
     return send_from_directory(app.static_folder, path)
+
+# Ensure the database schema exists when the application starts
+init_db()
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5001, debug=True)


### PR DESCRIPTION
## Summary
- replace JSON storage with a simple SQLite database
- update endpoints to read and write using sqlite
- ignore generated `tweets.db`

## Testing
- `python -m py_compile app.py llm_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684625328ab883239d82d84f2a9a1d89