### PR TITLE
Add tweet deletion and prompts viewer

### DIFF
--- a/static/prompts.html
+++ b/static/prompts.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prompts</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Prompt Database</h1>
+            <a href="index.html" class="back-button">Back</a>
+        </header>
+        <main id="prompts-container"></main>
+    </div>
+    <script src="prompts.js"></script>
+</body>
+</html>

--- a/static/prompts.js
+++ b/static/prompts.js
@@ -1,0 +1,20 @@
+(() => {
+    async function loadPrompts() {
+        const personaRes = await fetch('/api/personas');
+        const personas = await personaRes.json();
+
+        const sysRes = await fetch('/api/system_prompt');
+        const sysData = await sysRes.json();
+
+        const container = document.getElementById('prompts-container');
+        const personaList = personas.map(p => `<li><strong>${p.name}</strong>: ${p.prompt}</li>`).join('');
+        container.innerHTML = `
+            <h2>Personas</h2>
+            <ul>${personaList}</ul>
+            <h2>System Instructions</h2>
+            <pre>${sysData.system_prompt}</pre>
+        `;
+    }
+
+    document.addEventListener('DOMContentLoaded', loadPrompts);
+})();

--- a/static/script.js
+++ b/static/script.js
@@ -61,11 +61,10 @@
                     ${quotedTweetHTML}
                     <p class="tweet-meta">${this.formatDate(tweet.timestamp)}</p>
                     <div class="tweet-actions">
-                        <button class="action-button reply-btn" data-tweet-id="${tweet.id}" data-username="${tweet.username}">
-                            Reply ${replyCount}
-                        </button>
+                        <button class="action-button reply-btn" data-tweet-id="${tweet.id}" data-username="${tweet.username}">Reply ${replyCount}</button>
                         <a href="#/tweet/${tweet.id}/quotes" class="action-link quote-btn">Quote ${quoteCount}</a>
                         <button class="action-button like-btn" data-tweet-id="${tweet.id}">Like ${likeCount}</button>
+                        <button class="action-button delete-btn" data-tweet-id="${tweet.id}">Delete</button>
                     </div>
                 </div>`;
         },
@@ -73,7 +72,7 @@
         getComposerHTML() { /* Unchanged from previous version */ return `<div id="composer-context"></div><div class="tweet-form-container"><form id="tweet-form"><input type="text" id="username-input" placeholder="Your Username" value="${this.state.lastUsername}" required><textarea id="tweet-text-input" placeholder="What's happening?" required maxlength="280"></textarea><button type="submit">Tweet</button></form></div>`; },
         renderMainFeed(tweets) {
             this.elements.mainContent.innerHTML = `
-                <header><h1>LAN Twitter</h1></header>
+                <header><h1>LAN Twitter</h1><a href="prompts.html" class="prompts-link">Prompts</a></header>
                 ${this.getComposerHTML()}
                 <div id="tweet-feed">
                     ${tweets.map(t => this.getTweetHTML(t)).join('')}
@@ -97,6 +96,12 @@
                 this.state.allTweetsById[tweetId] = updatedTweet; // Update local cache
                 this.router(); // Re-render to show new count
                 return; // Stop further processing
+            }
+
+            if (target.classList.contains('delete-btn')) {
+                await fetch(`/api/tweets/${tweetId}`, { method: 'DELETE' });
+                this.router();
+                return;
             }
 
             if (target.closest('.tweet:not(.parent-tweet)') && !target.closest('.action-button, .action-link') && !target.closest('a')) { window.location.hash = `#/tweet/${tweetId}`; } 

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,8 @@
 body { font-family: system-ui, sans-serif; background-color: #f0f2f5; margin: 0; }
 .container { max-width: 600px; width: 100%; margin: 0 auto; background-color: #fff; min-height: 100vh; border-left: 1px solid #ddd; border-right: 1px solid #ddd; }
-header, .tweet-form-container { padding: 15px; border-bottom: 1px solid #ddd; }
+header, .tweet-form-container { padding: 15px; border-bottom: 1px solid #ddd; display: flex; justify-content: space-between; align-items: center; }
 h1, .view-header h2 { margin: 0; font-size: 20px; }
+.prompts-link { text-decoration: none; color: #1DA1F2; font-size: 14px; }
 .view-header { display: flex; align-items: center; gap: 15px; padding: 15px; border-bottom: 1px solid #ddd; }
 .back-button { font-size: 20px; text-decoration: none; color: #1c1e21; }
 #tweet-form { display: flex; flex-direction: column; gap: 10px; }


### PR DESCRIPTION
## Summary
- implement prompts database init and retrieval endpoints
- return system prompt instructions via API
- add DELETE endpoint for tweets
- link to a new prompts page and support deleting tweets from the feed
- basic UI to view personas and system instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846360154d88323944b69db434f38dc