### PR TITLE
Add persona and system prompt management

### DIFF
--- a/static/prompts.js
+++ b/static/prompts.js
@@ -7,13 +7,77 @@
         const sysData = await sysRes.json();
 
         const container = document.getElementById('prompts-container');
-        const personaList = personas.map(p => `<li><strong>${p.name}</strong>: ${p.prompt}</li>`).join('');
+        const personaList = personas.map(p => `
+            <li data-name="${p.name}">
+                <strong>${p.name}</strong>: <span class="prompt-text">${p.prompt}</span>
+                <button class="edit-persona-btn">Edit</button>
+                <button class="delete-persona-btn">Delete</button>
+            </li>
+        `).join('');
         container.innerHTML = `
             <h2>Personas</h2>
-            <ul>${personaList}</ul>
+            <ul id="persona-list">${personaList}</ul>
+            <button id="add-persona-btn">Add Persona</button>
             <h2>System Instructions</h2>
-            <pre>${sysData.system_prompt}</pre>
+            <textarea id="system-prompt-input" rows="10" style="width:100%;">${sysData.system_prompt}</textarea>
+            <br><button id="save-system-prompt">Save</button>
         `;
+
+        attachEvents();
+    }
+
+    async function addPersona() {
+        const name = prompt('Persona name:');
+        if (!name) return;
+        const promptText = prompt('Persona prompt:');
+        if (!promptText) return;
+        await fetch('/api/personas', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, prompt: promptText })
+        });
+        loadPrompts();
+    }
+
+    async function editPersona(e) {
+        const li = e.target.closest('li');
+        const oldName = li.dataset.name;
+        const newName = prompt('Persona name:', oldName);
+        if (!newName) return;
+        const oldPrompt = li.querySelector('.prompt-text').textContent;
+        const newPrompt = prompt('Persona prompt:', oldPrompt);
+        if (newPrompt === null) return;
+        await fetch('/api/personas/' + encodeURIComponent(oldName), {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: newName, prompt: newPrompt })
+        });
+        loadPrompts();
+    }
+
+    async function deletePersona(e) {
+        const li = e.target.closest('li');
+        const name = li.dataset.name;
+        if (!confirm(`Delete persona ${name}?`)) return;
+        await fetch('/api/personas/' + encodeURIComponent(name), { method: 'DELETE' });
+        loadPrompts();
+    }
+
+    async function saveSystemPrompt() {
+        const text = document.getElementById('system-prompt-input').value;
+        await fetch('/api/system_prompt', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ system_prompt: text })
+        });
+        alert('Saved');
+    }
+
+    function attachEvents() {
+        document.getElementById('add-persona-btn').addEventListener('click', addPersona);
+        document.querySelectorAll('.edit-persona-btn').forEach(btn => btn.addEventListener('click', editPersona));
+        document.querySelectorAll('.delete-persona-btn').forEach(btn => btn.addEventListener('click', deletePersona));
+        document.getElementById('save-system-prompt').addEventListener('click', saveSystemPrompt);
     }
 
     document.addEventListener('DOMContentLoaded', loadPrompts);

--- a/static/style.css
+++ b/static/style.css
@@ -29,3 +29,10 @@ h1, .view-header h2 { margin: 0; font-size: 20px; }
 .quoted-tweet-container .tweet-text { margin-top: 3px; }
 #composer-context { padding: 0 15px 10px 15px; font-size: 0.9em; color: #657786; }
 #composer-context button { background: none; border: none; color: #1DA1F2; cursor: pointer; font-size: 1em; padding-left: 5px; }
+
+/* Prompts page */
+#persona-list { list-style: none; padding: 0; }
+#persona-list li { padding: 10px; border-bottom: 1px solid #eee; }
+#persona-list button { margin-left: 10px; }
+#add-persona-btn, #save-system-prompt { margin: 10px 0; padding: 8px 12px; }
+#system-prompt-input { border: 1px solid #ccc; border-radius: 6px; padding: 10px; font-family: inherit; }


### PR DESCRIPTION
## Summary
- allow managing personas and system prompt in database
- expose CRUD API endpoints for personas and system prompt
- add GUI controls on the prompts page
- style the prompts page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846c6073b9c8323bfd6de0b96eb85f0