### PR TITLE
Add llm bot trigger button and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LAN Twitter Sandbox
+
+This project is a small Flask application that emulates a minimal social network for local experiments with language model bots. Tweets and persona prompts are stored in SQLite databases and served via JSON API endpoints.
+
+## Key Components
+
+- **app.py** – Flask server exposing REST endpoints for tweets, personas, and system prompts. Static files in `static/` provide a simple single-page interface.
+- **llm_bot.py** – Script that chooses a persona, summarizes recent tweets, queries an LLM through OpenRouter, and posts the result back to the server. The new function `run_bot()` allows launching a single cycle programmatically.
+- **static/** – Contains `index.html` with the timeline view, JavaScript for UI logic, and CSS styling. The front end polls the API and lets users tweet, reply, like, and delete.
+
+A new `/api/run_bot` endpoint triggers `run_bot()` in a background thread. The main feed now has a “Run Bot” button next to the tweet composer so you can watch bots interact with each other in the timeline.
+
+This codebase is intentionally lightweight; it is designed as a playground rather than a production system. Use it to test prompt ideas or observe multiple personas conversing without exposing the interface to the broader internet.

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 import datetime
 import sqlite3
 from flask import Flask, request, jsonify, send_from_directory
+from threading import Thread
+import llm_bot
 from collections import Counter
 
 PROMPT_DB_FILE = 'prompts.db'
@@ -355,6 +357,13 @@ def set_system_prompt():
 @app.route('/api/token_usage', methods=['GET'])
 def get_token_usage():
     return jsonify(load_token_usage())
+
+
+@app.route('/api/run_bot', methods=['POST'])
+def trigger_bot():
+    """Start a single LLM bot cycle in a background thread."""
+    Thread(target=llm_bot.run_bot).start()
+    return jsonify({'status': 'running'}), 202
 
 @app.route('/')
 def serve_index():

--- a/static/script.js
+++ b/static/script.js
@@ -69,7 +69,20 @@
                 </div>`;
         },
 
-        getComposerHTML() { /* Unchanged from previous version */ return `<div id="composer-context"></div><div class="tweet-form-container"><form id="tweet-form"><input type="text" id="username-input" placeholder="Your Username" value="${this.state.lastUsername}" required><textarea id="tweet-text-input" placeholder="What's happening?" required maxlength="280"></textarea><button type="submit">Tweet</button></form></div>`; },
+        getComposerHTML() {
+            return `
+                <div id="composer-context"></div>
+                <div class="tweet-form-container">
+                    <form id="tweet-form">
+                        <input type="text" id="username-input" placeholder="Your Username" value="${this.state.lastUsername}" required>
+                        <textarea id="tweet-text-input" placeholder="What's happening?" required maxlength="280"></textarea>
+                        <div class="button-row">
+                            <button type="button" id="run-bot-btn">Run Bot</button>
+                            <button type="submit">Tweet</button>
+                        </div>
+                    </form>
+                </div>`;
+        },
         renderMainFeed(tweets) {
             this.elements.mainContent.innerHTML = `
                 <header><h1>LAN Twitter</h1><a href="prompts.html" class="prompts-link">Prompts</a> <a href="tokens.html" class="prompts-link">Usage</a></header>
@@ -81,7 +94,16 @@
         renderTweetDetailView(tweetId, tweets) { const parentTweet = this.state.allTweetsById[tweetId]; if (!parentTweet) { this.elements.mainContent.innerHTML = `<h2>Tweet not found</h2><a href="#">Back</a>`; return; } const replies = tweets.filter(t => t.replying_to === parentTweet.id); this.elements.mainContent.innerHTML = `<div class="view-header"><a href="#" class="back-button">←</a><h2>Thread</h2></div><div id="tweet-feed">${this.getTweetHTML(parentTweet, true)}${replies.map(t => this.getTweetHTML(t)).join('')}</div>${this.getComposerHTML()}`; this.state.composer = { replying_to: { id: parentTweet.id, username: parentTweet.username }, quoting: null }; document.getElementById('composer-context').innerHTML = `Replying to @${parentTweet.username} <button id="cancel-action">Cancel</button>`; },
         renderQuotesView(tweetId, tweets) { const parentTweet = this.state.allTweetsById[tweetId]; if (!parentTweet) { this.elements.mainContent.innerHTML = `<h2>Tweet not found</h2><a href="#">Back</a>`; return; } const quotes = tweets.filter(t => t.quoting_tweet_id === parentTweet.id); this.elements.mainContent.innerHTML = `<div class="view-header"><a href="#/tweet/${tweetId}" class="back-button">←</a><h2>Quotes for Tweet by @${parentTweet.username}</h2></div><div id="tweet-feed">${quotes.map(t => this.getTweetHTML(t)).join('')}</div>`; },
 
-        attachEventListeners() { this.elements.mainContent.addEventListener('click', e => this.handleMainClick(e)); const tweetForm = document.getElementById('tweet-form'); if (tweetForm) { tweetForm.addEventListener('submit', e => this.handleFormSubmit(e)); document.getElementById('tweet-text-input').addEventListener('keydown', e => this.handleKeyDown(e)); } },
+        attachEventListeners() {
+            this.elements.mainContent.addEventListener('click', e => this.handleMainClick(e));
+            const tweetForm = document.getElementById('tweet-form');
+            if (tweetForm) {
+                tweetForm.addEventListener('submit', e => this.handleFormSubmit(e));
+                document.getElementById('tweet-text-input').addEventListener('keydown', e => this.handleKeyDown(e));
+            }
+            const runBotBtn = document.getElementById('run-bot-btn');
+            if (runBotBtn) runBotBtn.addEventListener('click', () => this.runBot());
+        },
 
         async handleMainClick(e) {
             const target = e.target;
@@ -112,6 +134,7 @@
         },
 
         async handleFormSubmit(e) { e.preventDefault(); const usernameInput = document.getElementById('username-input'); const username = usernameInput.value.trim(); const text = document.getElementById('tweet-text-input').value.trim(); if (!username || !text) return; const payload = { username, text }; if (this.state.composer.replying_to) payload.replying_to = parseInt(this.state.composer.replying_to.id); await fetch('/api/tweets', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload), }); localStorage.setItem('lanTwttrUsername', username); this.state.lastUsername = username; this.router(); },
+        async runBot() { await fetch('/api/run_bot', { method: 'POST' }); },
         handleKeyDown(e) { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); document.getElementById('tweet-form').requestSubmit(); } }
     };
 

--- a/static/style.css
+++ b/static/style.css
@@ -8,8 +8,11 @@ h1, .view-header h2 { margin: 0; font-size: 20px; }
 #tweet-form { display: flex; flex-direction: column; gap: 10px; }
 #username-input, #tweet-text-input { border: 1px solid #ccc; border-radius: 6px; padding: 10px; font-size: 16px; font-family: inherit; }
 #tweet-text-input { min-height: 80px; resize: vertical; }
-#tweet-form button { background-color: #1DA1F2; color: white; border: none; padding: 10px 20px; border-radius: 9999px; font-weight: bold; font-size: 16px; cursor: pointer; align-self: flex-end; }
+#tweet-form button { background-color: #1DA1F2; color: white; border: none; padding: 10px 20px; border-radius: 9999px; font-weight: bold; font-size: 16px; cursor: pointer; }
 #tweet-form button:hover { background-color: #0c85d0; }
+.button-row { display: flex; gap: 10px; justify-content: flex-end; }
+#run-bot-btn { background-color: #6c757d; }
+#run-bot-btn:hover { background-color: #5a6268; }
 .tweet { padding: 15px; border-bottom: 1px solid #eee; cursor: pointer; }
 .tweet:hover { background-color: #f5f8fa; }
 .tweet.parent-tweet { border-bottom: 10px solid #e1e8ed; cursor: default; }


### PR DESCRIPTION
## Summary
- add endpoint `/api/run_bot` to run the LLM bot once
- expose `run_bot()` function from `llm_bot.py`
- add Run Bot button next to tweet composer
- style the new button
- provide short README describing the project

## Testing
- `python -m py_compile app.py llm_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6846d0a091708323bfe63afa3b30e116